### PR TITLE
item setters should have safety annotations

### DIFF
--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderAuxiliarySettersUtils.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderAuxiliarySettersUtils.java
@@ -21,6 +21,7 @@ import com.palantir.conjure.java.types.BeanGenerator.EnrichedField;
 import com.palantir.conjure.java.util.Javadoc;
 import com.palantir.conjure.java.visitor.DefaultTypeVisitor;
 import com.palantir.conjure.spec.FieldDefinition;
+import com.palantir.conjure.spec.LogSafety;
 import com.palantir.conjure.spec.MapType;
 import com.palantir.conjure.spec.OptionalType;
 import com.palantir.conjure.spec.PrimitiveType;
@@ -72,9 +73,15 @@ public final class BeanBuilderAuxiliarySettersUtils {
     }
 
     public static MethodSpec.Builder createItemSetterBuilder(
-            EnrichedField enriched, Type itemType, TypeMapper typeMapper, ClassName returnClass) {
+            EnrichedField enriched,
+            Type itemType,
+            TypeMapper typeMapper,
+            ClassName returnClass,
+            Optional<LogSafety> safety) {
         FieldSpec field = enriched.poetSpec();
-        return publicSetter(enriched, returnClass).addParameter(typeMapper.getClassName(itemType), field.name);
+        return publicSetter(enriched, returnClass)
+                .addParameter(
+                        typeMapper.getClassName(itemType).annotated(ConjureAnnotations.safety(safety)), field.name);
     }
 
     public static MethodSpec.Builder createMapSetterBuilder(

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
@@ -35,6 +35,7 @@ import com.palantir.conjure.spec.ExternalReference;
 import com.palantir.conjure.spec.FieldDefinition;
 import com.palantir.conjure.spec.FieldName;
 import com.palantir.conjure.spec.ListType;
+import com.palantir.conjure.spec.LogSafety;
 import com.palantir.conjure.spec.MapType;
 import com.palantir.conjure.spec.ObjectDefinition;
 import com.palantir.conjure.spec.OptionalType;
@@ -426,17 +427,18 @@ public final class BeanBuilderGenerator {
 
     private List<MethodSpec> createAuxiliarySetters(EnrichedField enriched, boolean override) {
         Type type = enriched.conjureDef().getType();
+        Optional<LogSafety> safety = enriched.conjureDef().getSafety();
 
         if (type.accept(TypeVisitor.IS_LIST)) {
             return ImmutableList.of(
                     createCollectionSetter("addAll", enriched, override),
-                    createItemSetter(enriched, type.accept(TypeVisitor.LIST).getItemType(), override));
+                    createItemSetter(enriched, type.accept(TypeVisitor.LIST).getItemType(), override, safety));
         }
 
         if (type.accept(TypeVisitor.IS_SET)) {
             return ImmutableList.of(
                     createCollectionSetter("addAll", enriched, override),
-                    createItemSetter(enriched, type.accept(TypeVisitor.SET).getItemType(), override));
+                    createItemSetter(enriched, type.accept(TypeVisitor.SET).getItemType(), override, safety));
         }
 
         if (type.accept(TypeVisitor.IS_MAP)) {
@@ -488,9 +490,11 @@ public final class BeanBuilderGenerator {
                         optionalType.getItemType().accept(TypeVisitor.PRIMITIVE).get());
     }
 
-    private MethodSpec createItemSetter(EnrichedField enriched, Type itemType, boolean override) {
+    private MethodSpec createItemSetter(
+            EnrichedField enriched, Type itemType, boolean override, Optional<LogSafety> safety) {
         FieldSpec field = enriched.poetSpec();
-        return BeanBuilderAuxiliarySettersUtils.createItemSetterBuilder(enriched, itemType, typeMapper, builderClass)
+        return BeanBuilderAuxiliarySettersUtils.createItemSetterBuilder(
+                        enriched, itemType, typeMapper, builderClass, safety)
                 .addAnnotations(ConjureAnnotations.override(override))
                 .addCode(verifyNotBuilt())
                 .addStatement("this.$1N.add($1N)", field.name)

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanGenerator.java
@@ -347,7 +347,11 @@ public final class BeanGenerator {
                     .addModifiers(Modifier.ABSTRACT)
                     .build());
             methodSpecs.add(BeanBuilderAuxiliarySettersUtils.createItemSetterBuilder(
-                            enriched, type.accept(TypeVisitor.LIST).getItemType(), typeMapper, returnClass)
+                            enriched,
+                            type.accept(TypeVisitor.LIST).getItemType(),
+                            typeMapper,
+                            returnClass,
+                            definition.getSafety())
                     .addModifiers(Modifier.ABSTRACT)
                     .build());
         }
@@ -358,7 +362,11 @@ public final class BeanGenerator {
                     .addModifiers(Modifier.ABSTRACT)
                     .build());
             methodSpecs.add(BeanBuilderAuxiliarySettersUtils.createItemSetterBuilder(
-                            enriched, type.accept(TypeVisitor.SET).getItemType(), typeMapper, returnClass)
+                            enriched,
+                            type.accept(TypeVisitor.SET).getItemType(),
+                            typeMapper,
+                            returnClass,
+                            definition.getSafety())
                     .addModifiers(Modifier.ABSTRACT)
                     .build());
         }


### PR DESCRIPTION
previously, item setters for collection types didn't have safety annotations, even for primitive collections. For example, a field of type List<boolean> would generate the following setter:

```
       public Builder listBoolean(String listBoolean) {
            checkNotBuilt();
            this.listBoolean.add(listBoolean);
            return this;
        }
```
Now, both primitive and external import collections generate item setters that look like:

```
        public Builder listBoolean(@Safe String listBoolean) {
            checkNotBuilt();
            this.listBoolean.add(listBoolean);
            return this;
        }
```