### PR TITLE
external imports have safety annotations

### DIFF
--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/DangerousLongAlias.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/DangerousLongAlias.java
@@ -2,9 +2,11 @@ package com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.logsafe.DoNotLog;
 import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
+@DoNotLog
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class DangerousLongAlias {
     private final long value;
@@ -14,11 +16,13 @@ public final class DangerousLongAlias {
     }
 
     @JsonValue
+    @DoNotLog
     public long get() {
         return value;
     }
 
     @Override
+    @DoNotLog
     public String toString() {
         return String.valueOf(value);
     }
@@ -35,7 +39,7 @@ public final class DangerousLongAlias {
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
-    public static DangerousLongAlias of(long value) {
+    public static DangerousLongAlias of(@DoNotLog long value) {
         return new DangerousLongAlias(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongUnionExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/ExternalLongUnionExample.java
@@ -40,7 +40,7 @@ public final class ExternalLongUnionExample {
         return value;
     }
 
-    public static ExternalLongUnionExample safeLong(long value) {
+    public static ExternalLongUnionExample safeLong(@Safe long value) {
         return new ExternalLongUnionExample(new SafeLongWrapper(value));
     }
 
@@ -79,7 +79,7 @@ public final class ExternalLongUnionExample {
     }
 
     public interface Visitor<T> {
-        T visitSafeLong(long value);
+        T visitSafeLong(@Safe long value);
 
         T visitUnknown(@Safe String unknownType, Object unknownValue);
 
@@ -90,12 +90,12 @@ public final class ExternalLongUnionExample {
 
     private static final class VisitorBuilder<T>
             implements SafeLongStageVisitorBuilder<T>, UnknownStageVisitorBuilder<T>, Completed_StageVisitorBuilder<T> {
-        private Function<Long, T> safeLongVisitor;
+        private Function<@Safe Long, T> safeLongVisitor;
 
         private BiFunction<@Safe String, Object, T> unknownVisitor;
 
         @Override
-        public UnknownStageVisitorBuilder<T> safeLong(@Nonnull Function<Long, T> safeLongVisitor) {
+        public UnknownStageVisitorBuilder<T> safeLong(@Nonnull Function<@Safe Long, T> safeLongVisitor) {
             Preconditions.checkNotNull(safeLongVisitor, "safeLongVisitor cannot be null");
             this.safeLongVisitor = safeLongVisitor;
             return this;
@@ -127,7 +127,7 @@ public final class ExternalLongUnionExample {
 
         @Override
         public Visitor<T> build() {
-            final Function<Long, T> safeLongVisitor = this.safeLongVisitor;
+            final Function<@Safe Long, T> safeLongVisitor = this.safeLongVisitor;
             final BiFunction<@Safe String, Object, T> unknownVisitor = this.unknownVisitor;
             return new Visitor<T>() {
                 @Override
@@ -144,7 +144,7 @@ public final class ExternalLongUnionExample {
     }
 
     public interface SafeLongStageVisitorBuilder<T> {
-        UnknownStageVisitorBuilder<T> safeLong(@Nonnull Function<Long, T> safeLongVisitor);
+        UnknownStageVisitorBuilder<T> safeLong(@Nonnull Function<@Safe Long, T> safeLongVisitor);
     }
 
     public interface UnknownStageVisitorBuilder<T> {

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeExternalLongAlias.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeExternalLongAlias.java
@@ -2,9 +2,11 @@ package com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.logsafe.Safe;
 import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
+@Safe
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class SafeExternalLongAlias {
     private final long value;
@@ -14,11 +16,13 @@ public final class SafeExternalLongAlias {
     }
 
     @JsonValue
+    @Safe
     public long get() {
         return value;
     }
 
     @Override
+    @Safe
     public String toString() {
         return String.valueOf(value);
     }
@@ -35,12 +39,12 @@ public final class SafeExternalLongAlias {
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
-    public static SafeExternalLongAlias valueOf(String value) {
+    public static SafeExternalLongAlias valueOf(@Safe String value) {
         return of(Long.valueOf(value));
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
-    public static SafeExternalLongAlias of(long value) {
+    public static SafeExternalLongAlias of(@Safe long value) {
         return new SafeExternalLongAlias(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeExternalLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeExternalLongExample.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.palantir.conjure.java.lib.internal.ConjureCollections;
 import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
@@ -20,6 +21,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
+@Safe
 @JsonDeserialize(builder = SafeExternalLongExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
 public final class SafeExternalLongExample {
@@ -46,22 +48,26 @@ public final class SafeExternalLongExample {
     }
 
     @JsonProperty("safeExternalLongValue")
+    @Safe
     public long getSafeExternalLongValue() {
         return this.safeExternalLongValue;
     }
 
     @JsonProperty("optionalSafeExternalLong")
+    @Safe
     @JsonInclude(JsonInclude.Include.NON_ABSENT)
     public Optional<Long> getOptionalSafeExternalLong() {
         return this.optionalSafeExternalLong;
     }
 
     @JsonProperty("safeExternalLongList")
+    @Safe
     public List<Long> getSafeExternalLongList() {
         return this.safeExternalLongList;
     }
 
     @JsonProperty("safeExternalLongSet")
+    @Safe
     public Set<Long> getSafeExternalLongSet() {
         return this.safeExternalLongSet;
     }
@@ -99,6 +105,7 @@ public final class SafeExternalLongExample {
     }
 
     @Override
+    @Safe
     public String toString() {
         return "SafeExternalLongExample{safeExternalLongValue: " + safeExternalLongValue
                 + ", optionalSafeExternalLong: " + optionalSafeExternalLong + ", safeExternalLongList: "
@@ -138,11 +145,11 @@ public final class SafeExternalLongExample {
 
         private long safeExternalLongValue;
 
-        private Optional<Long> optionalSafeExternalLong = Optional.empty();
+        private Optional<@Safe Long> optionalSafeExternalLong = Optional.empty();
 
-        private List<Long> safeExternalLongList = new ArrayList<>();
+        private List<@Safe Long> safeExternalLongList = new ArrayList<>();
 
-        private Set<Long> safeExternalLongSet = new LinkedHashSet<>();
+        private Set<@Safe Long> safeExternalLongSet = new LinkedHashSet<>();
 
         private boolean _safeExternalLongValueInitialized = false;
 
@@ -158,7 +165,7 @@ public final class SafeExternalLongExample {
         }
 
         @JsonSetter("safeExternalLongValue")
-        public Builder safeExternalLongValue(long safeExternalLongValue) {
+        public Builder safeExternalLongValue(@Safe long safeExternalLongValue) {
             checkNotBuilt();
             this.safeExternalLongValue = safeExternalLongValue;
             this._safeExternalLongValueInitialized = true;
@@ -166,7 +173,7 @@ public final class SafeExternalLongExample {
         }
 
         @JsonSetter(value = "optionalSafeExternalLong", nulls = Nulls.SKIP)
-        public Builder optionalSafeExternalLong(@Nonnull Optional<? extends Long> optionalSafeExternalLong) {
+        public Builder optionalSafeExternalLong(@Safe @Nonnull Optional<? extends Long> optionalSafeExternalLong) {
             checkNotBuilt();
             this.optionalSafeExternalLong = Preconditions.checkNotNull(
                             optionalSafeExternalLong, "optionalSafeExternalLong cannot be null")
@@ -174,7 +181,7 @@ public final class SafeExternalLongExample {
             return this;
         }
 
-        public Builder optionalSafeExternalLong(long optionalSafeExternalLong) {
+        public Builder optionalSafeExternalLong(@Safe long optionalSafeExternalLong) {
             checkNotBuilt();
             this.optionalSafeExternalLong = Optional.of(
                     Preconditions.checkNotNull(optionalSafeExternalLong, "optionalSafeExternalLong cannot be null"));
@@ -182,14 +189,14 @@ public final class SafeExternalLongExample {
         }
 
         @JsonSetter(value = "safeExternalLongList", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
-        public Builder safeExternalLongList(@Nonnull Iterable<? extends Long> safeExternalLongList) {
+        public Builder safeExternalLongList(@Safe @Nonnull Iterable<? extends Long> safeExternalLongList) {
             checkNotBuilt();
             this.safeExternalLongList = ConjureCollections.newArrayList(
                     Preconditions.checkNotNull(safeExternalLongList, "safeExternalLongList cannot be null"));
             return this;
         }
 
-        public Builder addAllSafeExternalLongList(@Nonnull Iterable<? extends Long> safeExternalLongList) {
+        public Builder addAllSafeExternalLongList(@Safe @Nonnull Iterable<? extends Long> safeExternalLongList) {
             checkNotBuilt();
             ConjureCollections.addAll(
                     this.safeExternalLongList,
@@ -197,21 +204,21 @@ public final class SafeExternalLongExample {
             return this;
         }
 
-        public Builder safeExternalLongList(long safeExternalLongList) {
+        public Builder safeExternalLongList(@Safe long safeExternalLongList) {
             checkNotBuilt();
             this.safeExternalLongList.add(safeExternalLongList);
             return this;
         }
 
         @JsonSetter(value = "safeExternalLongSet", nulls = Nulls.SKIP, contentNulls = Nulls.FAIL)
-        public Builder safeExternalLongSet(@Nonnull Iterable<? extends Long> safeExternalLongSet) {
+        public Builder safeExternalLongSet(@Safe @Nonnull Iterable<? extends Long> safeExternalLongSet) {
             checkNotBuilt();
             this.safeExternalLongSet = ConjureCollections.newLinkedHashSet(
                     Preconditions.checkNotNull(safeExternalLongSet, "safeExternalLongSet cannot be null"));
             return this;
         }
 
-        public Builder addAllSafeExternalLongSet(@Nonnull Iterable<? extends Long> safeExternalLongSet) {
+        public Builder addAllSafeExternalLongSet(@Safe @Nonnull Iterable<? extends Long> safeExternalLongSet) {
             checkNotBuilt();
             ConjureCollections.addAll(
                     this.safeExternalLongSet,
@@ -219,7 +226,7 @@ public final class SafeExternalLongExample {
             return this;
         }
 
-        public Builder safeExternalLongSet(long safeExternalLongSet) {
+        public Builder safeExternalLongSet(@Safe long safeExternalLongSet) {
             checkNotBuilt();
             this.safeExternalLongSet.add(safeExternalLongSet);
             return this;

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongAlias.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/SafeLongAlias.java
@@ -2,9 +2,11 @@ package com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.logsafe.Safe;
 import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
+@Safe
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class SafeLongAlias {
     private final long value;
@@ -14,11 +16,13 @@ public final class SafeLongAlias {
     }
 
     @JsonValue
+    @Safe
     public long get() {
         return value;
     }
 
     @Override
+    @Safe
     public String toString() {
         return String.valueOf(value);
     }
@@ -34,7 +38,7 @@ public final class SafeLongAlias {
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
-    public static SafeLongAlias of(long value) {
+    public static SafeLongAlias of(@Safe long value) {
         return new SafeLongAlias(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowExternalLongTestService.java
+++ b/conjure-java-core/src/integrationInput/java/com/palantir/product/UndertowExternalLongTestService.java
@@ -1,5 +1,7 @@
 package com.palantir.product;
 
+import com.palantir.logsafe.DoNotLog;
+import com.palantir.logsafe.Safe;
 import com.palantir.tokens.auth.AuthHeader;
 import javax.annotation.processing.Generated;
 
@@ -8,12 +10,12 @@ public interface UndertowExternalLongTestService {
     /**
      * @apiNote {@code POST /external-long/testDangerousLong}
      */
-    void testDangerousLong(AuthHeader authHeader, long dangerousLong);
+    void testDangerousLong(AuthHeader authHeader, @DoNotLog long dangerousLong);
 
     /**
      * @apiNote {@code POST /external-long/testSafeExternalLong}
      */
-    void testSafeExternalLong(AuthHeader authHeader, long safeExternalLong);
+    void testSafeExternalLong(AuthHeader authHeader, @Safe long safeExternalLong);
 
     /**
      * @apiNote {@code POST /external-long/testLong}

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongUnionExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/ExternalLongUnionExample.java
@@ -39,7 +39,7 @@ public final class ExternalLongUnionExample {
         return value;
     }
 
-    public static ExternalLongUnionExample safeLong(long value) {
+    public static ExternalLongUnionExample safeLong(@Safe long value) {
         return new ExternalLongUnionExample(new SafeLongWrapper(value));
     }
 
@@ -78,7 +78,7 @@ public final class ExternalLongUnionExample {
     }
 
     public interface Visitor<T> {
-        T visitSafeLong(long value);
+        T visitSafeLong(@Safe long value);
 
         T visitUnknown(@Safe String unknownType);
 
@@ -89,12 +89,12 @@ public final class ExternalLongUnionExample {
 
     private static final class VisitorBuilder<T>
             implements SafeLongStageVisitorBuilder<T>, UnknownStageVisitorBuilder<T>, Completed_StageVisitorBuilder<T> {
-        private Function<Long, T> safeLongVisitor;
+        private Function<@Safe Long, T> safeLongVisitor;
 
         private Function<String, T> unknownVisitor;
 
         @Override
-        public UnknownStageVisitorBuilder<T> safeLong(@Nonnull Function<Long, T> safeLongVisitor) {
+        public UnknownStageVisitorBuilder<T> safeLong(@Nonnull Function<@Safe Long, T> safeLongVisitor) {
             Preconditions.checkNotNull(safeLongVisitor, "safeLongVisitor cannot be null");
             this.safeLongVisitor = safeLongVisitor;
             return this;
@@ -119,7 +119,7 @@ public final class ExternalLongUnionExample {
 
         @Override
         public Visitor<T> build() {
-            final Function<Long, T> safeLongVisitor = this.safeLongVisitor;
+            final Function<@Safe Long, T> safeLongVisitor = this.safeLongVisitor;
             final Function<String, T> unknownVisitor = this.unknownVisitor;
             return new Visitor<T>() {
                 @Override
@@ -136,7 +136,7 @@ public final class ExternalLongUnionExample {
     }
 
     public interface SafeLongStageVisitorBuilder<T> {
-        UnknownStageVisitorBuilder<T> safeLong(@Nonnull Function<Long, T> safeLongVisitor);
+        UnknownStageVisitorBuilder<T> safeLong(@Nonnull Function<@Safe Long, T> safeLongVisitor);
     }
 
     public interface UnknownStageVisitorBuilder<T> {

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SafeExternalLongAlias.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SafeExternalLongAlias.java
@@ -2,9 +2,11 @@ package test.prefix.com.palantir.product;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import com.palantir.logsafe.Safe;
 import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
+@Safe
 @Generated("com.palantir.conjure.java.types.AliasGenerator")
 public final class SafeExternalLongAlias {
     private final long value;
@@ -14,11 +16,13 @@ public final class SafeExternalLongAlias {
     }
 
     @JsonValue
+    @Safe
     public long get() {
         return value;
     }
 
     @Override
+    @Safe
     public String toString() {
         return String.valueOf(value);
     }
@@ -35,12 +39,12 @@ public final class SafeExternalLongAlias {
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
-    public static SafeExternalLongAlias valueOf(String value) {
+    public static SafeExternalLongAlias valueOf(@Safe String value) {
         return of(Long.valueOf(value));
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
-    public static SafeExternalLongAlias of(long value) {
+    public static SafeExternalLongAlias of(@Safe long value) {
         return new SafeExternalLongAlias(value);
     }
 }

--- a/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SafeExternalLongExample.java
+++ b/conjure-java-core/src/integrationInput/java/test/prefix/com/palantir/product/SafeExternalLongExample.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.palantir.conjure.java.lib.internal.ConjureCollections;
 import com.palantir.logsafe.Preconditions;
+import com.palantir.logsafe.Safe;
 import com.palantir.logsafe.SafeArg;
 import com.palantir.logsafe.exceptions.SafeIllegalArgumentException;
 import java.util.ArrayList;
@@ -21,6 +22,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.processing.Generated;
 
+@Safe
 @JsonDeserialize(builder = SafeExternalLongExample.Builder.class)
 @Generated("com.palantir.conjure.java.types.BeanGenerator")
 public final class SafeExternalLongExample {
@@ -47,22 +49,26 @@ public final class SafeExternalLongExample {
     }
 
     @JsonProperty("safeExternalLongValue")
+    @Safe
     public long getSafeExternalLongValue() {
         return this.safeExternalLongValue;
     }
 
     @JsonProperty("optionalSafeExternalLong")
+    @Safe
     @JsonInclude(JsonInclude.Include.NON_ABSENT)
     public Optional<Long> getOptionalSafeExternalLong() {
         return this.optionalSafeExternalLong;
     }
 
     @JsonProperty("safeExternalLongList")
+    @Safe
     public List<Long> getSafeExternalLongList() {
         return this.safeExternalLongList;
     }
 
     @JsonProperty("safeExternalLongSet")
+    @Safe
     public Set<Long> getSafeExternalLongSet() {
         return this.safeExternalLongSet;
     }
@@ -100,6 +106,7 @@ public final class SafeExternalLongExample {
     }
 
     @Override
+    @Safe
     public String toString() {
         return "SafeExternalLongExample{safeExternalLongValue: " + safeExternalLongValue
                 + ", optionalSafeExternalLong: " + optionalSafeExternalLong + ", safeExternalLongList: "
@@ -140,11 +147,11 @@ public final class SafeExternalLongExample {
 
         private long safeExternalLongValue;
 
-        private Optional<Long> optionalSafeExternalLong = Optional.empty();
+        private Optional<@Safe Long> optionalSafeExternalLong = Optional.empty();
 
-        private List<Long> safeExternalLongList = new ArrayList<>();
+        private List<@Safe Long> safeExternalLongList = new ArrayList<>();
 
-        private Set<Long> safeExternalLongSet = new LinkedHashSet<>();
+        private Set<@Safe Long> safeExternalLongSet = new LinkedHashSet<>();
 
         private boolean _safeExternalLongValueInitialized = false;
 
@@ -160,7 +167,7 @@ public final class SafeExternalLongExample {
         }
 
         @JsonSetter("safeExternalLongValue")
-        public Builder safeExternalLongValue(long safeExternalLongValue) {
+        public Builder safeExternalLongValue(@Safe long safeExternalLongValue) {
             checkNotBuilt();
             this.safeExternalLongValue = safeExternalLongValue;
             this._safeExternalLongValueInitialized = true;
@@ -168,7 +175,7 @@ public final class SafeExternalLongExample {
         }
 
         @JsonSetter(value = "optionalSafeExternalLong", nulls = Nulls.SKIP)
-        public Builder optionalSafeExternalLong(@Nonnull Optional<? extends Long> optionalSafeExternalLong) {
+        public Builder optionalSafeExternalLong(@Safe @Nonnull Optional<? extends Long> optionalSafeExternalLong) {
             checkNotBuilt();
             this.optionalSafeExternalLong = Preconditions.checkNotNull(
                             optionalSafeExternalLong, "optionalSafeExternalLong cannot be null")
@@ -176,7 +183,7 @@ public final class SafeExternalLongExample {
             return this;
         }
 
-        public Builder optionalSafeExternalLong(long optionalSafeExternalLong) {
+        public Builder optionalSafeExternalLong(@Safe long optionalSafeExternalLong) {
             checkNotBuilt();
             this.optionalSafeExternalLong = Optional.of(
                     Preconditions.checkNotNull(optionalSafeExternalLong, "optionalSafeExternalLong cannot be null"));
@@ -184,14 +191,14 @@ public final class SafeExternalLongExample {
         }
 
         @JsonSetter(value = "safeExternalLongList", nulls = Nulls.SKIP)
-        public Builder safeExternalLongList(@Nonnull Iterable<? extends Long> safeExternalLongList) {
+        public Builder safeExternalLongList(@Safe @Nonnull Iterable<? extends Long> safeExternalLongList) {
             checkNotBuilt();
             this.safeExternalLongList = ConjureCollections.newArrayList(
                     Preconditions.checkNotNull(safeExternalLongList, "safeExternalLongList cannot be null"));
             return this;
         }
 
-        public Builder addAllSafeExternalLongList(@Nonnull Iterable<? extends Long> safeExternalLongList) {
+        public Builder addAllSafeExternalLongList(@Safe @Nonnull Iterable<? extends Long> safeExternalLongList) {
             checkNotBuilt();
             ConjureCollections.addAll(
                     this.safeExternalLongList,
@@ -199,21 +206,21 @@ public final class SafeExternalLongExample {
             return this;
         }
 
-        public Builder safeExternalLongList(long safeExternalLongList) {
+        public Builder safeExternalLongList(@Safe long safeExternalLongList) {
             checkNotBuilt();
             this.safeExternalLongList.add(safeExternalLongList);
             return this;
         }
 
         @JsonSetter(value = "safeExternalLongSet", nulls = Nulls.SKIP)
-        public Builder safeExternalLongSet(@Nonnull Iterable<? extends Long> safeExternalLongSet) {
+        public Builder safeExternalLongSet(@Safe @Nonnull Iterable<? extends Long> safeExternalLongSet) {
             checkNotBuilt();
             this.safeExternalLongSet = ConjureCollections.newLinkedHashSet(
                     Preconditions.checkNotNull(safeExternalLongSet, "safeExternalLongSet cannot be null"));
             return this;
         }
 
-        public Builder addAllSafeExternalLongSet(@Nonnull Iterable<? extends Long> safeExternalLongSet) {
+        public Builder addAllSafeExternalLongSet(@Safe @Nonnull Iterable<? extends Long> safeExternalLongSet) {
             checkNotBuilt();
             ConjureCollections.addAll(
                     this.safeExternalLongSet,
@@ -221,7 +228,7 @@ public final class SafeExternalLongExample {
             return this;
         }
 
-        public Builder safeExternalLongSet(long safeExternalLongSet) {
+        public Builder safeExternalLongSet(@Safe long safeExternalLongSet) {
             checkNotBuilt();
             this.safeExternalLongSet.add(safeExternalLongSet);
             return this;

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/ConjureTags.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/ConjureTags.java
@@ -18,6 +18,7 @@ package com.palantir.conjure.java;
 
 import com.google.common.collect.ImmutableSet;
 import com.palantir.conjure.java.types.SafetyEvaluator;
+import com.palantir.conjure.java.util.SafetyUtils;
 import com.palantir.conjure.spec.ArgumentDefinition;
 import com.palantir.conjure.spec.EndpointDefinition;
 import com.palantir.conjure.spec.LogSafety;
@@ -80,8 +81,9 @@ public final class ConjureTags {
 
     public static Optional<LogSafety> safety(ArgumentDefinition argument) {
         validateTags(argument);
-        if (argument.getSafety().isPresent()) {
-            return argument.getSafety();
+        Optional<LogSafety> argumentSafety = SafetyUtils.getUsageTimeSafety(argument);
+        if (argumentSafety.isPresent()) {
+            return argumentSafety;
         }
         Set<String> tags = argument.getTags();
         if (isSafe(tags)) {
@@ -104,18 +106,19 @@ public final class ConjureTags {
                     isSafe(tags) ? "safe" : "unsafe",
                     argument.getArgName()));
         }
-        if (argument.getSafety().isPresent()) {
+        Optional<LogSafety> argumentSafety = SafetyUtils.getUsageTimeSafety(argument);
+        if (argumentSafety.isPresent()) {
             if (markerSafety.isPresent()) {
                 throw new IllegalStateException(String.format(
                         "Unexpected 'safety: %s' value in addition to a '%s' marker on argument '%s'",
-                        argument.getSafety().get().accept(DefFormatSafetyVisitor.INSTANCE),
+                        argumentSafety.get().accept(DefFormatSafetyVisitor.INSTANCE),
                         markerSafety.get().accept(MarkerNameLogSafetyVisitor.INSTANCE),
                         argument.getArgName()));
             }
             if (isSafe(tags) || isUnsafe(tags)) {
                 throw new IllegalStateException(String.format(
                         "Unexpected 'safety: %s' value in addition to a '%s' tag on argument '%s'",
-                        argument.getSafety().get().accept(DefFormatSafetyVisitor.INSTANCE),
+                        argumentSafety.get().accept(DefFormatSafetyVisitor.INSTANCE),
                         isSafe(tags) ? "safe" : "unsafe",
                         argument.getArgName()));
             }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/AliasGenerator.java
@@ -23,6 +23,7 @@ import com.palantir.conjure.java.Options;
 import com.palantir.conjure.java.lib.SafeLong;
 import com.palantir.conjure.java.util.Javadoc;
 import com.palantir.conjure.java.util.Packages;
+import com.palantir.conjure.java.util.SafetyUtils;
 import com.palantir.conjure.java.visitor.MoreVisitors;
 import com.palantir.conjure.spec.AliasDefinition;
 import com.palantir.conjure.spec.ExternalReference;
@@ -65,13 +66,12 @@ public final class AliasGenerator {
             TypeMapper typeMapper, SafetyEvaluator safetyEvaluator, AliasDefinition typeDef, Options options) {
         com.palantir.conjure.spec.TypeName prefixedTypeName =
                 Packages.getPrefixedName(typeDef.getTypeName(), options.packagePrefix());
-        TypeName aliasTypeName =
-                ConjureAnnotations.withSafety(typeMapper.getClassName(typeDef.getAlias()), typeDef.getSafety());
+        Optional<LogSafety> safety = SafetyUtils.getUsageTimeSafety(typeDef);
+        TypeName aliasTypeName = ConjureAnnotations.withSafety(typeMapper.getClassName(typeDef.getAlias()), safety);
 
         ClassName thisClass = ClassName.get(prefixedTypeName.getPackage(), prefixedTypeName.getName());
-        Optional<LogSafety> safety = typeDef.getSafety();
         ImmutableList<AnnotationSpec> safetyAnnotations = ConjureAnnotations.safety(safety);
-        Optional<LogSafety> computedSafety = safetyEvaluator.evaluate(typeDef.getAlias(), typeDef.getSafety());
+        Optional<LogSafety> computedSafety = safetyEvaluator.evaluate(typeDef.getAlias(), safety);
         ImmutableList<AnnotationSpec> computedSafetyAnnotations = ConjureAnnotations.safety(computedSafety);
 
         TypeSpec.Builder spec = TypeSpec.classBuilder(prefixedTypeName.getName())

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderAuxiliarySettersUtils.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderAuxiliarySettersUtils.java
@@ -19,6 +19,7 @@ package com.palantir.conjure.java.types;
 import com.palantir.conjure.java.ConjureAnnotations;
 import com.palantir.conjure.java.types.BeanGenerator.EnrichedField;
 import com.palantir.conjure.java.util.Javadoc;
+import com.palantir.conjure.java.util.SafetyUtils;
 import com.palantir.conjure.java.visitor.DefaultTypeVisitor;
 import com.palantir.conjure.spec.FieldDefinition;
 import com.palantir.conjure.spec.LogSafety;
@@ -58,7 +59,7 @@ public final class BeanBuilderAuxiliarySettersUtils {
                 .addParameter(Parameters.nonnullParameter(
                         widenParameterIfPossible(field.type, type, typeMapper),
                         field.name,
-                        enriched.conjureDef().getSafety()));
+                        SafetyUtils.getUsageTimeSafety(enriched.conjureDef())));
     }
 
     public static MethodSpec.Builder createOptionalSetterBuilder(
@@ -69,7 +70,7 @@ public final class BeanBuilderAuxiliarySettersUtils {
                 .addParameter(Parameters.nonnullParameter(
                         typeMapper.getClassName(type.getItemType()),
                         field.name,
-                        enriched.conjureDef().getSafety()));
+                        SafetyUtils.getUsageTimeSafety(enriched.conjureDef())));
     }
 
     public static MethodSpec.Builder createItemSetterBuilder(

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/BeanBuilderGenerator.java
@@ -27,6 +27,7 @@ import com.palantir.conjure.java.Options;
 import com.palantir.conjure.java.lib.internal.ConjureCollections;
 import com.palantir.conjure.java.types.BeanGenerator.EnrichedField;
 import com.palantir.conjure.java.util.JavaNameSanitizer;
+import com.palantir.conjure.java.util.SafetyUtils;
 import com.palantir.conjure.java.util.TypeFunctions;
 import com.palantir.conjure.java.visitor.DefaultTypeVisitor;
 import com.palantir.conjure.java.visitor.DefaultableTypeVisitor;
@@ -264,7 +265,8 @@ public final class BeanBuilderGenerator {
 
     private EnrichedField createField(FieldName fieldName, FieldDefinition field) {
         Type type = field.getType();
-        TypeName typeName = ConjureAnnotations.withSafety(typeMapper.getClassName(type), field.getSafety());
+        TypeName typeName =
+                ConjureAnnotations.withSafety(typeMapper.getClassName(type), SafetyUtils.getUsageTimeSafety(field));
         FieldSpec.Builder spec = FieldSpec.builder(typeName, JavaNameSanitizer.sanitize(fieldName), Modifier.PRIVATE);
         if (type.accept(TypeVisitor.IS_LIST) || type.accept(TypeVisitor.IS_SET) || type.accept(TypeVisitor.IS_MAP)) {
             spec.initializer("new $T<>()", type.accept(COLLECTION_CONCRETE_TYPE));
@@ -329,7 +331,7 @@ public final class BeanBuilderGenerator {
                 .addParameter(Parameters.nonnullParameter(
                         BeanBuilderAuxiliarySettersUtils.widenParameterIfPossible(field.type, type, typeMapper),
                         field.name,
-                        enriched.conjureDef().getSafety()))
+                        SafetyUtils.getUsageTimeSafety(enriched.conjureDef())))
                 .addCode(verifyNotBuilt())
                 .addCode(typeAwareAssignment(enriched, type, shouldClearFirst));
 
@@ -427,7 +429,7 @@ public final class BeanBuilderGenerator {
 
     private List<MethodSpec> createAuxiliarySetters(EnrichedField enriched, boolean override) {
         Type type = enriched.conjureDef().getType();
-        Optional<LogSafety> safety = enriched.conjureDef().getSafety();
+        Optional<LogSafety> safety = SafetyUtils.getUsageTimeSafety(enriched.conjureDef());
 
         if (type.accept(TypeVisitor.IS_LIST)) {
             return ImmutableList.of(

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/ErrorGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/ErrorGenerator.java
@@ -27,6 +27,7 @@ import com.palantir.conjure.java.api.errors.RemoteException;
 import com.palantir.conjure.java.api.errors.ServiceException;
 import com.palantir.conjure.java.util.Javadoc;
 import com.palantir.conjure.java.util.Packages;
+import com.palantir.conjure.java.util.SafetyUtils;
 import com.palantir.conjure.java.util.TypeFunctions;
 import com.palantir.conjure.spec.ConjureDefinition;
 import com.palantir.conjure.spec.ErrorDefinition;
@@ -165,16 +166,17 @@ public final class ErrorGenerator implements Generator {
                                                     .build()))
                                     .map(arg -> {
                                         TypeName argumentTypeName = typeMapper.getClassName(arg.getType());
-                                        Optional<LogSafety> required = arg.getSafety();
+                                        Optional<LogSafety> underlyingTypeSafety = SafetyUtils.getUsageTimeSafety(arg);
                                         Optional<LogSafety> typeSafety = safetyEvaluator.evaluate(arg.getType());
-                                        if (!SafetyEvaluator.allows(required, typeSafety)) {
+                                        if (!SafetyEvaluator.allows(underlyingTypeSafety, typeSafety)) {
                                             throw new IllegalStateException(String.format(
                                                     "Cannot use %s type %s as a %s parameter in error %s -> %s",
                                                     typeSafety
                                                             .map(Object::toString)
                                                             .orElse("unknown"),
                                                     argumentTypeName,
-                                                    required.map(Object::toString)
+                                                    underlyingTypeSafety
+                                                            .map(Object::toString)
                                                             .orElse("unknown"),
                                                     entry.getErrorName().getName(),
                                                     arg.getFieldName()));
@@ -182,7 +184,7 @@ public final class ErrorGenerator implements Generator {
                                         return ParameterSpec.builder(
                                                         argumentTypeName,
                                                         arg.getFieldName().get())
-                                                .addAnnotations(ConjureAnnotations.safety(arg.getSafety()))
+                                                .addAnnotations(ConjureAnnotations.safety(underlyingTypeSafety))
                                                 .addJavadoc(
                                                         "$L",
                                                         StringUtils.appendIfMissing(

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/SafetyEvaluator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/SafetyEvaluator.java
@@ -187,9 +187,8 @@ public final class SafetyEvaluator {
         }
 
         @Override
-        public Optional<LogSafety> visitExternal(ExternalReference _value) {
-            // External types have unknown safety for now
-            return Optional.empty();
+        public Optional<LogSafety> visitExternal(ExternalReference value) {
+            return value.getSafety();
         }
 
         @Override

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/types/UnionGenerator.java
@@ -34,6 +34,7 @@ import com.palantir.conjure.java.Options;
 import com.palantir.conjure.java.util.JavaNameSanitizer;
 import com.palantir.conjure.java.util.Javadoc;
 import com.palantir.conjure.java.util.Packages;
+import com.palantir.conjure.java.util.SafetyUtils;
 import com.palantir.conjure.java.util.StableCollectors;
 import com.palantir.conjure.java.util.TypeFunctions;
 import com.palantir.conjure.java.visitor.DefaultableTypeVisitor;
@@ -104,7 +105,7 @@ public final class UnionGenerator {
                 .collect(StableCollectors.toLinkedMap(
                         Function.identity(),
                         entry -> ConjureAnnotations.withSafety(
-                                typeMapper.getClassName(entry.getType()), entry.getSafety())));
+                                typeMapper.getClassName(entry.getType()), SafetyUtils.getUsageTimeSafety(entry))));
         List<FieldSpec> fields =
                 ImmutableList.of(FieldSpec.builder(baseClass, VALUE_FIELD_NAME, Modifier.PRIVATE, Modifier.FINAL)
                         .build());
@@ -179,7 +180,8 @@ public final class UnionGenerator {
                     MethodSpec.Builder builder = MethodSpec.methodBuilder(JavaNameSanitizer.sanitize(memberName))
                             .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
                             .addParameter(ParameterSpec.builder(memberType, variableName)
-                                    .addAnnotations(ConjureAnnotations.safety(memberTypeDef.getSafety()))
+                                    .addAnnotations(
+                                            ConjureAnnotations.safety(SafetyUtils.getUsageTimeSafety(memberTypeDef)))
                                     .build())
                             .addStatement(
                                     "return new $T(new $T($L))",
@@ -314,8 +316,8 @@ public final class UnionGenerator {
                                     entry.getKey().getDeprecated()))
                             .addModifiers(Modifier.PUBLIC, Modifier.ABSTRACT)
                             .addParameter(ParameterSpec.builder(entry.getValue(), variableName)
-                                    .addAnnotations(ConjureAnnotations.safety(
-                                            entry.getKey().getSafety()))
+                                    .addAnnotations(
+                                            ConjureAnnotations.safety(SafetyUtils.getUsageTimeSafety(entry.getKey())))
                                     .build())
                             .returns(TYPE_VARIABLE)
                             .build();
@@ -650,7 +652,7 @@ public final class UnionGenerator {
                         .map(entry -> new NameTypeMetadata(
                                 sanitizeUnknown(entry.getKey().getFieldName().get()),
                                 entry.getValue(),
-                                entry.getKey().getSafety()))
+                                SafetyUtils.getUsageTimeSafety(entry.getKey())))
                         .sorted(Comparator.comparing(p -> p.memberName)),
                 Stream.of(NameTypeMetadata.UNKNOWN));
     }

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/util/SafetyUtils.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/util/SafetyUtils.java
@@ -1,0 +1,103 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.util;
+
+import com.palantir.conjure.java.types.SafetyEvaluator;
+import com.palantir.conjure.spec.AliasDefinition;
+import com.palantir.conjure.spec.ArgumentDefinition;
+import com.palantir.conjure.spec.ExternalReference;
+import com.palantir.conjure.spec.FieldDefinition;
+import com.palantir.conjure.spec.ListType;
+import com.palantir.conjure.spec.LogSafety;
+import com.palantir.conjure.spec.MapType;
+import com.palantir.conjure.spec.OptionalType;
+import com.palantir.conjure.spec.PrimitiveType;
+import com.palantir.conjure.spec.SetType;
+import com.palantir.conjure.spec.Type;
+import com.palantir.conjure.spec.TypeName;
+import java.util.Optional;
+
+public final class SafetyUtils {
+    private SafetyUtils() {}
+
+    public static Optional<LogSafety> getUsageTimeSafety(AliasDefinition alias, SafetyEvaluator safetyEvaluator) {
+        if (alias.getAlias().accept(RequiresSafetyAtUsageTime.INSTANCE)) {
+            return safetyEvaluator.evaluate(alias.getAlias(), alias.getSafety());
+        }
+        return alias.getSafety();
+    }
+
+    public static Optional<LogSafety> getUsageTimeSafety(FieldDefinition field, SafetyEvaluator safetyEvaluator) {
+        if (field.getType().accept(RequiresSafetyAtUsageTime.INSTANCE)) {
+            return safetyEvaluator.evaluate(field.getType(), field.getSafety());
+        }
+        return field.getSafety();
+    }
+
+    public static Optional<LogSafety> getUsageTimeSafety(ArgumentDefinition argument, SafetyEvaluator safetyEvaluator) {
+        if (argument.getType().accept(RequiresSafetyAtUsageTime.INSTANCE)) {
+            return safetyEvaluator.evaluate(argument.getType(), argument.getSafety());
+        }
+        return argument.getSafety();
+    }
+
+    // primitive and external types (and types that wrap them) must declare their safety at usage time
+    // for all other types, assume the generated class declares safety at definition time
+    private enum RequiresSafetyAtUsageTime implements Type.Visitor<Boolean> {
+        INSTANCE;
+
+        @Override
+        public java.lang.Boolean visitPrimitive(PrimitiveType _value) {
+            return true;
+        }
+
+        @Override
+        public Boolean visitOptional(OptionalType value) {
+            return value.getItemType().accept(INSTANCE);
+        }
+
+        @Override
+        public Boolean visitList(ListType value) {
+            return value.getItemType().accept(INSTANCE);
+        }
+
+        @Override
+        public Boolean visitSet(SetType value) {
+            return value.getItemType().accept(INSTANCE);
+        }
+
+        @Override
+        public Boolean visitMap(MapType _value) {
+            return false;
+        }
+
+        @Override
+        public Boolean visitReference(TypeName _value) {
+            return false;
+        }
+
+        @Override
+        public Boolean visitExternal(ExternalReference _value) {
+            return true;
+        }
+
+        @Override
+        public Boolean visitUnknown(String _unknownType) {
+            return false;
+        }
+    }
+}

--- a/conjure-java-core/src/main/java/com/palantir/conjure/java/util/SafetyUtils.java
+++ b/conjure-java-core/src/main/java/com/palantir/conjure/java/util/SafetyUtils.java
@@ -16,6 +16,7 @@
 
 package com.palantir.conjure.java.util;
 
+import com.google.common.collect.ImmutableMap;
 import com.palantir.conjure.java.types.SafetyEvaluator;
 import com.palantir.conjure.spec.AliasDefinition;
 import com.palantir.conjure.spec.ArgumentDefinition;
@@ -34,21 +35,25 @@ import java.util.Optional;
 public final class SafetyUtils {
     private SafetyUtils() {}
 
-    public static Optional<LogSafety> getUsageTimeSafety(AliasDefinition alias, SafetyEvaluator safetyEvaluator) {
+    // SafetyEvaluator uses its TypeDefinitionMap to resolve the safety of reference types, but these utils
+    // only evaluate the safety of external imports and primitives, so it's safe to use a placeholder
+    private static final SafetyEvaluator safetyEvaluator = new SafetyEvaluator(ImmutableMap.of());
+
+    public static Optional<LogSafety> getUsageTimeSafety(AliasDefinition alias) {
         if (alias.getAlias().accept(RequiresSafetyAtUsageTime.INSTANCE)) {
             return safetyEvaluator.evaluate(alias.getAlias(), alias.getSafety());
         }
         return alias.getSafety();
     }
 
-    public static Optional<LogSafety> getUsageTimeSafety(FieldDefinition field, SafetyEvaluator safetyEvaluator) {
+    public static Optional<LogSafety> getUsageTimeSafety(FieldDefinition field) {
         if (field.getType().accept(RequiresSafetyAtUsageTime.INSTANCE)) {
             return safetyEvaluator.evaluate(field.getType(), field.getSafety());
         }
         return field.getSafety();
     }
 
-    public static Optional<LogSafety> getUsageTimeSafety(ArgumentDefinition argument, SafetyEvaluator safetyEvaluator) {
+    public static Optional<LogSafety> getUsageTimeSafety(ArgumentDefinition argument) {
         if (argument.getType().accept(RequiresSafetyAtUsageTime.INSTANCE)) {
             return safetyEvaluator.evaluate(argument.getType(), argument.getSafety());
         }
@@ -61,8 +66,8 @@ public final class SafetyUtils {
         INSTANCE;
 
         @Override
-        public java.lang.Boolean visitPrimitive(PrimitiveType _value) {
-            return true;
+        public java.lang.Boolean visitPrimitive(PrimitiveType value) {
+            return !value.equals(PrimitiveType.BEARERTOKEN);
         }
 
         @Override

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/ConjureTagsTest.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/ConjureTagsTest.java
@@ -192,6 +192,37 @@ class ConjureTagsTest {
                 .hasMessageContaining("Declared argument safety is incompatible with the provided type");
     }
 
+    @Test
+    void testExternalImport_AtImportTime() {
+        SafetyEvaluator safetyEvaluator = new SafetyEvaluator(ImmutableMap.of());
+        Type external = Type.external(ExternalReference.builder()
+                .externalReference(TypeName.of("Long", "java.lang"))
+                .fallback(Type.primitive(PrimitiveType.STRING))
+                .safety(LogSafety.DO_NOT_LOG)
+                .build());
+        ArgumentDefinition argument = ArgumentDefinition.builder()
+                .argName(ArgumentName.of("testArgument"))
+                .type(external)
+                .paramType(ParameterType.body(BodyParameterType.of()))
+                .build();
+        assertThat(ConjureTags.validateArgument(argument, safetyEvaluator)).hasValue(LogSafety.DO_NOT_LOG);
+    }
+
+    @Test
+    void testExternalImport_NoSafety() {
+        SafetyEvaluator safetyEvaluator = new SafetyEvaluator(ImmutableMap.of());
+        Type external = Type.external(ExternalReference.builder()
+                .externalReference(TypeName.of("Long", "java.lang"))
+                .fallback(Type.primitive(PrimitiveType.STRING))
+                .build());
+        ArgumentDefinition argument = ArgumentDefinition.builder()
+                .argName(ArgumentName.of("testArgument"))
+                .type(external)
+                .paramType(ParameterType.body(BodyParameterType.of()))
+                .build();
+        assertThat(ConjureTags.validateArgument(argument, safetyEvaluator)).isEmpty();
+    }
+
     private static ArgumentDefinition tags(String... tags) {
         return ArgumentDefinition.builder()
                 .argName(ArgumentName.of("name"))

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/ExternalImportSafetyTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/ExternalImportSafetyTests.java
@@ -1,0 +1,247 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.logsafe.DoNotLog;
+import com.palantir.logsafe.Safe;
+import com.palantir.product.ExternalLongUnionExample;
+import com.palantir.product.SafeExternalLongExample;
+import com.palantir.product.UndertowExternalLongTestService;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedParameterizedType;
+import java.lang.reflect.AnnotatedType;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import test.prefix.com.palantir.product.SafeExternalLongAlias;
+
+public class ExternalImportSafetyTests {
+    @Test
+    public void testAliasAnnotations() {
+        assertThat(SafeExternalLongAlias.class).hasAnnotation(Safe.class);
+
+        assertMethodHasAnnotation(SafeExternalLongAlias.class, "toString", Safe.class);
+        assertMethodHasAnnotation(SafeExternalLongAlias.class, "get", Safe.class);
+        assertMethodParamHasAnnotation(SafeExternalLongAlias.class, "valueOf", "value", Safe.class);
+        assertMethodParamHasAnnotation(SafeExternalLongAlias.class, "of", "value", Safe.class);
+    }
+
+    @Test
+    public void testObjectAnnotations() {
+        assertThat(SafeExternalLongExample.class).hasAnnotation(Safe.class);
+
+        assertMethodHasAnnotation(SafeExternalLongExample.class, "toString", Safe.class);
+        assertMethodHasAnnotation(SafeExternalLongExample.class, "getSafeExternalLongValue", Safe.class);
+
+        Class<?> builder = getMatchingSubclass(SafeExternalLongExample.class, "Builder");
+        assertMethodParamHasAnnotation(builder, "safeExternalLongValue", "safeExternalLongValue", Safe.class);
+    }
+
+    @Test
+    public void testServiceAnnotations() {
+        assertMethodParamHasAnnotation(
+                UndertowExternalLongTestService.class, "testDangerousLong", "dangerousLong", DoNotLog.class);
+        assertMethodParamHasAnnotation(
+                UndertowExternalLongTestService.class, "testSafeExternalLong", "safeExternalLong", Safe.class);
+
+        assertMethodParamHasNoAnnotation(UndertowExternalLongTestService.class, "testLong", "long_");
+        assertMethodParamHasNoAnnotation(
+                UndertowExternalLongTestService.class, "testDangerousLongAlias", "dangerousLongAlias");
+        assertMethodParamHasNoAnnotation(
+                UndertowExternalLongTestService.class, "testSafeExternalLongAlias", "safeExternalLongAlias");
+        assertMethodParamHasNoAnnotation(UndertowExternalLongTestService.class, "testLongAlias", "longAlias");
+    }
+
+    @Test
+    public void testUnionAnnotations() {
+        assertMethodParamHasAnnotation(ExternalLongUnionExample.class, "safeLong", "value", Safe.class);
+        assertMethodParamHasAnnotation(ExternalLongUnionExample.class, "unknown", "type", Safe.class);
+
+        Class<?> visitor = getExactlyMatchingSubclass(
+                ExternalLongUnionExample.class, "com.palantir.product.ExternalLongUnionExample$Visitor");
+        assertMethodParamHasAnnotation(visitor, "visitSafeLong", "value", Safe.class);
+        assertMethodParamHasAnnotation(visitor, "visitUnknown", "unknownType", Safe.class);
+
+        Class<?> visitorBuilder = getExactlyMatchingSubclass(
+                ExternalLongUnionExample.class, "com.palantir.product.ExternalLongUnionExample$VisitorBuilder");
+        assertFieldTypeParamHasAnnotation(visitorBuilder, "safeLongVisitor", "Long", Safe.class);
+        assertFieldTypeParamHasAnnotation(visitorBuilder, "unknownVisitor", "String", Safe.class);
+        assertMethodParamWithTypeParameterHasAnnotation(visitorBuilder, "safeLong", "safeLong", "Long", Safe.class);
+        assertMethodParamWithTypeParameterHasAnnotation(visitorBuilder, "unknown", "unknown", "String", Safe.class);
+
+        Class<?> stageVisitorBuilder =
+                getMatchingSubclass(ExternalLongUnionExample.class, "SafeLongStageVisitorBuilder");
+        assertMethodParamWithTypeParameterHasAnnotation(
+                stageVisitorBuilder, "safeLong", "safeLongVisitor", "Long", Safe.class);
+
+        Class<?> unknownStageVisitorBuilder =
+                getMatchingSubclass(ExternalLongUnionExample.class, "UnknownStageVisitorBuilder");
+        assertMethodParamWithTypeParameterHasAnnotation(
+                unknownStageVisitorBuilder, "unknown", "unknownVisitor", "String", Safe.class);
+    }
+
+    @Test
+    public void testOptionalAnnotations() {
+        assertMethodHasAnnotation(SafeExternalLongExample.class, "getOptionalSafeExternalLong", Safe.class);
+
+        Class<?> builderSubclass = getMatchingSubclass(SafeExternalLongExample.class, "$Builder");
+        assertFieldTypeParamHasAnnotation(builderSubclass, "optionalSafeExternalLong", "Long", Safe.class);
+        assertMethodParamHasAnnotation(
+                builderSubclass, "optionalSafeExternalLong", "optionalSafeExternalLong", Safe.class);
+    }
+
+    @Test
+    public void testListAnnotations() {
+        assertMethodHasAnnotation(SafeExternalLongExample.class, "getSafeExternalLongList", Safe.class);
+
+        Class<?> builderSubclass = getMatchingSubclass(SafeExternalLongExample.class, "$Builder");
+        assertFieldTypeParamHasAnnotation(builderSubclass, "safeExternalLongList", "Long", Safe.class);
+        assertMethodParamHasAnnotation(builderSubclass, "safeExternalLongList", "safeExternalLongList", Safe.class);
+        assertMethodParamHasAnnotation(
+                builderSubclass, "addAllSafeExternalLongList", "safeExternalLongList", Safe.class);
+    }
+
+    @Test
+    public void testSetAnnotations() {
+        assertMethodHasAnnotation(SafeExternalLongExample.class, "getSafeExternalLongSet", Safe.class);
+
+        Class<?> builderSubclass = getMatchingSubclass(SafeExternalLongExample.class, "$Builder");
+        assertFieldTypeParamHasAnnotation(builderSubclass, "safeExternalLongSet", "Long", Safe.class);
+        assertMethodParamHasAnnotation(builderSubclass, "safeExternalLongSet", "safeExternalLongSet", Safe.class);
+        assertMethodParamHasAnnotation(builderSubclass, "addAllSafeExternalLongSet", "safeExternalLongSet", Safe.class);
+    }
+
+    private void assertMethodHasAnnotation(
+            Class<?> parentClass, String methodName, Class<? extends Annotation> annotation) {
+        Stream<Method> desiredMethods = getMatchingMethods(parentClass, methodName);
+        assertThat(desiredMethods)
+                .withFailMessage(String.format(
+                        "Expected %s:%s to have annotation %s",
+                        parentClass.getName(), methodName, annotation.getName()))
+                .allMatch(method -> method.isAnnotationPresent(annotation));
+    }
+
+    private void assertMethodParamHasAnnotation(
+            Class<?> parentClass, String methodName, String parameterName, Class<? extends Annotation> annotation) {
+        Stream<Method> desiredMethods = getMatchingMethods(parentClass, methodName);
+        assertThat(desiredMethods)
+                .withFailMessage(String.format(
+                        "Expected %s:%s parameter %s to have annotation %s",
+                        parentClass.getName(), methodName, parameterName, annotation.getName()))
+                .map(method -> getMatchingParameter(method, parameterName))
+                .allMatch(parameter -> parameter.isAnnotationPresent(annotation));
+    }
+
+    private void assertMethodParamHasNoAnnotation(Class<?> parentClass, String methodName, String parameterName) {
+        Stream<Method> desiredMethods = getMatchingMethods(parentClass, methodName);
+        assertThat(desiredMethods)
+                .withFailMessage(String.format(
+                        "Expected %s:%s parameter %s to have no annotation",
+                        parentClass.getName(), methodName, parameterName))
+                .map(method -> getMatchingParameter(method, parameterName))
+                .allMatch(parameter -> parameter.getAnnotations().length == 0);
+    }
+
+    private void assertMethodParamWithTypeParameterHasAnnotation(
+            Class<?> parentClass,
+            String methodName,
+            String parameterName,
+            String typeParameter,
+            Class<? extends Annotation> annotation) {
+        Stream<Method> desiredMethods = getMatchingMethods(parentClass, methodName);
+        Stream<AnnotatedType> annotatedTypes = desiredMethods.map(
+                method -> getMatchingParameter(method, parameterName).getAnnotatedType());
+        assertThat(annotatedTypes)
+                .withFailMessage(String.format(
+                        "Expected %s:%s parameter %s of type %s to have annotation %s",
+                        parentClass.getName(), methodName, parameterName, typeParameter, annotation.getName()))
+                .map(annotatedType -> getAnnotatedTypeParameter(annotatedType, typeParameter))
+                .allMatch(t -> t.isAnnotationPresent(annotation));
+    }
+
+    private void assertFieldTypeParamHasAnnotation(
+            Class<?> parentClass, String fieldName, String typeName, Class<? extends Annotation> annotation) {
+        Stream<Field> desiredFields = Arrays.stream(parentClass.getDeclaredFields())
+                .filter(field -> field.getName().contains(fieldName));
+        Stream<AnnotatedType> annotatedTypeParameters =
+                desiredFields.map(Field::getAnnotatedType).map(type -> getAnnotatedTypeParameter(type, typeName));
+        assertThat(annotatedTypeParameters)
+                .withFailMessage(String.format(
+                        "Expected %s:%s of type %s to have annotation %s",
+                        parentClass.getName(), fieldName, typeName, annotation.getName()))
+                .allMatch(t -> t.isAnnotationPresent(annotation));
+    }
+
+    private Stream<Method> getMatchingMethods(Class<?> parentClass, String methodName) {
+        List<Method> methods = Arrays.stream(parentClass.getMethods())
+                .filter(method -> method.getName().equals(methodName))
+                .collect(Collectors.toList());
+        assertThat(methods)
+                .withFailMessage(String.format("Expected method %s on class %s", methodName, parentClass.getName()))
+                .isNotEmpty();
+        return methods.stream();
+    }
+
+    private Class<?> getMatchingSubclass(Class<?> parentClass, String subclassName) {
+        Optional<Class<?>> subclassIfExists = Arrays.stream(parentClass.getDeclaredClasses())
+                .filter(subclass -> subclass.getName().contains(subclassName))
+                .findAny();
+        assertThat(subclassIfExists)
+                .withFailMessage(String.format("Expected %s:%s to exist", parentClass, subclassName))
+                .isPresent();
+        return subclassIfExists.get();
+    }
+
+    private Class<?> getExactlyMatchingSubclass(Class<?> parentClass, String subclassName) {
+        Optional<Class<?>> subclassIfExists = Arrays.stream(parentClass.getDeclaredClasses())
+                .filter(subclass -> subclass.getName().equals(subclassName))
+                .findAny();
+        assertThat(subclassIfExists)
+                .withFailMessage(String.format("Expected %s:%s to exist", parentClass, subclassName))
+                .isPresent();
+        return subclassIfExists.get();
+    }
+
+    private Parameter getMatchingParameter(Method method, String parameterName) {
+        Optional<Parameter> parameterIfExists = Arrays.stream(method.getParameters())
+                .filter(parameter -> parameter.getName().contains(parameterName))
+                .findAny();
+        assertThat(parameterIfExists)
+                .withFailMessage(String.format("Expected to find parameter %s on method %s", parameterName, method))
+                .isPresent();
+        return parameterIfExists.get();
+    }
+
+    private AnnotatedType getAnnotatedTypeParameter(AnnotatedType parameterizedType, String parameter) {
+        Optional<AnnotatedType> typeParameterIfExists = Arrays.stream(
+                        ((AnnotatedParameterizedType) parameterizedType).getAnnotatedActualTypeArguments())
+                .filter(t -> t.getType().getTypeName().contains(parameter))
+                .findAny();
+        assertThat(typeParameterIfExists)
+                .withFailMessage("Expected type parameter %s on type %s", parameter, parameterizedType)
+                .isPresent();
+        return typeParameterIfExists.get();
+    }
+}

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/util/SafetyUtilsTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/util/SafetyUtilsTests.java
@@ -1,0 +1,124 @@
+/*
+ * (c) Copyright 2023 Palantir Technologies Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.palantir.conjure.java.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.palantir.conjure.java.types.SafetyEvaluator;
+import com.palantir.conjure.spec.AliasDefinition;
+import com.palantir.conjure.spec.ConjureDefinition;
+import com.palantir.conjure.spec.ExternalReference;
+import com.palantir.conjure.spec.FieldDefinition;
+import com.palantir.conjure.spec.FieldName;
+import com.palantir.conjure.spec.ListType;
+import com.palantir.conjure.spec.LogSafety;
+import com.palantir.conjure.spec.PrimitiveType;
+import com.palantir.conjure.spec.Type;
+import com.palantir.conjure.spec.TypeDefinition;
+import com.palantir.conjure.spec.TypeName;
+import org.junit.jupiter.api.Test;
+
+public class SafetyUtilsTests {
+
+    private static final Type SAFE_EXTERNAL = Type.external(ExternalReference.builder()
+            .externalReference(TypeName.of("Long", "java.lang"))
+            .fallback(Type.primitive(PrimitiveType.STRING))
+            .safety(LogSafety.SAFE)
+            .build());
+
+    private static final ConjureDefinition conjureDef = ConjureDefinition.builder()
+            .version(1)
+            .types(TypeDefinition.alias(AliasDefinition.builder()
+                    .typeName(TypeName.of("LongAlias", "com.palantir.test"))
+                    .alias(SAFE_EXTERNAL)
+                    .build()))
+            .build();
+
+    private static final Type REFERENCE = Type.reference(TypeName.of("TestType", "com.palantir.test"));
+
+    private static final SafetyEvaluator safetyEvaluator = new SafetyEvaluator(conjureDef);
+
+    @Test
+    public void externalField() {
+        FieldDefinition field = FieldDefinition.builder()
+                .fieldName(FieldName.of("testField"))
+                .type(SAFE_EXTERNAL)
+                .build();
+        assertThat(SafetyUtils.getUsageTimeSafety(field, safetyEvaluator))
+                .isPresent()
+                .get()
+                .isEqualTo(LogSafety.SAFE);
+    }
+
+    @Test
+    public void primitiveField() {
+        FieldDefinition field = FieldDefinition.builder()
+                .fieldName(FieldName.of("testField"))
+                .type(Type.primitive(PrimitiveType.STRING))
+                .safety(LogSafety.SAFE)
+                .build();
+        assertThat(SafetyUtils.getUsageTimeSafety(field, safetyEvaluator))
+                .isPresent()
+                .get()
+                .isEqualTo(LogSafety.SAFE);
+    }
+
+    @Test
+    public void externalWrapper() {
+        FieldDefinition field = FieldDefinition.builder()
+                .fieldName(FieldName.of("testField"))
+                .type(Type.list(ListType.builder().itemType(SAFE_EXTERNAL).build()))
+                .build();
+        assertThat(SafetyUtils.getUsageTimeSafety(field, safetyEvaluator))
+                .isPresent()
+                .get()
+                .isEqualTo(LogSafety.SAFE);
+    }
+
+    @Test
+    public void primitiveWrapper() {
+        FieldDefinition field = FieldDefinition.builder()
+                .fieldName(FieldName.of("testField"))
+                .type(Type.list(ListType.builder()
+                        .itemType(Type.primitive(PrimitiveType.STRING))
+                        .build()))
+                .safety(LogSafety.SAFE)
+                .build();
+        assertThat(SafetyUtils.getUsageTimeSafety(field, safetyEvaluator))
+                .isPresent()
+                .get()
+                .isEqualTo(LogSafety.SAFE);
+    }
+
+    @Test
+    public void referenceField() {
+        FieldDefinition field = FieldDefinition.builder()
+                .fieldName(FieldName.of("testField"))
+                .type(REFERENCE)
+                .build();
+        assertThat(SafetyUtils.getUsageTimeSafety(field, safetyEvaluator)).isEmpty();
+    }
+
+    @Test
+    public void referenceFieldWrapper() {
+        FieldDefinition field = FieldDefinition.builder()
+                .fieldName(FieldName.of("testField"))
+                .type(Type.list(ListType.builder().itemType(REFERENCE).build()))
+                .build();
+        assertThat(SafetyUtils.getUsageTimeSafety(field, safetyEvaluator)).isEmpty();
+    }
+}

--- a/conjure-java-core/src/test/java/com/palantir/conjure/java/util/SafetyUtilsTests.java
+++ b/conjure-java-core/src/test/java/com/palantir/conjure/java/util/SafetyUtilsTests.java
@@ -18,9 +18,6 @@ package com.palantir.conjure.java.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.palantir.conjure.java.types.SafetyEvaluator;
-import com.palantir.conjure.spec.AliasDefinition;
-import com.palantir.conjure.spec.ConjureDefinition;
 import com.palantir.conjure.spec.ExternalReference;
 import com.palantir.conjure.spec.FieldDefinition;
 import com.palantir.conjure.spec.FieldName;
@@ -28,7 +25,6 @@ import com.palantir.conjure.spec.ListType;
 import com.palantir.conjure.spec.LogSafety;
 import com.palantir.conjure.spec.PrimitiveType;
 import com.palantir.conjure.spec.Type;
-import com.palantir.conjure.spec.TypeDefinition;
 import com.palantir.conjure.spec.TypeName;
 import org.junit.jupiter.api.Test;
 
@@ -40,28 +36,13 @@ public class SafetyUtilsTests {
             .safety(LogSafety.SAFE)
             .build());
 
-    private static final ConjureDefinition conjureDef = ConjureDefinition.builder()
-            .version(1)
-            .types(TypeDefinition.alias(AliasDefinition.builder()
-                    .typeName(TypeName.of("LongAlias", "com.palantir.test"))
-                    .alias(SAFE_EXTERNAL)
-                    .build()))
-            .build();
-
-    private static final Type REFERENCE = Type.reference(TypeName.of("TestType", "com.palantir.test"));
-
-    private static final SafetyEvaluator safetyEvaluator = new SafetyEvaluator(conjureDef);
-
     @Test
     public void externalField() {
         FieldDefinition field = FieldDefinition.builder()
                 .fieldName(FieldName.of("testField"))
                 .type(SAFE_EXTERNAL)
                 .build();
-        assertThat(SafetyUtils.getUsageTimeSafety(field, safetyEvaluator))
-                .isPresent()
-                .get()
-                .isEqualTo(LogSafety.SAFE);
+        assertThat(SafetyUtils.getUsageTimeSafety(field)).isPresent().get().isEqualTo(LogSafety.SAFE);
     }
 
     @Test
@@ -71,10 +52,7 @@ public class SafetyUtilsTests {
                 .type(Type.primitive(PrimitiveType.STRING))
                 .safety(LogSafety.SAFE)
                 .build();
-        assertThat(SafetyUtils.getUsageTimeSafety(field, safetyEvaluator))
-                .isPresent()
-                .get()
-                .isEqualTo(LogSafety.SAFE);
+        assertThat(SafetyUtils.getUsageTimeSafety(field)).isPresent().get().isEqualTo(LogSafety.SAFE);
     }
 
     @Test
@@ -83,10 +61,7 @@ public class SafetyUtilsTests {
                 .fieldName(FieldName.of("testField"))
                 .type(Type.list(ListType.builder().itemType(SAFE_EXTERNAL).build()))
                 .build();
-        assertThat(SafetyUtils.getUsageTimeSafety(field, safetyEvaluator))
-                .isPresent()
-                .get()
-                .isEqualTo(LogSafety.SAFE);
+        assertThat(SafetyUtils.getUsageTimeSafety(field)).isPresent().get().isEqualTo(LogSafety.SAFE);
     }
 
     @Test
@@ -98,27 +73,26 @@ public class SafetyUtilsTests {
                         .build()))
                 .safety(LogSafety.SAFE)
                 .build();
-        assertThat(SafetyUtils.getUsageTimeSafety(field, safetyEvaluator))
-                .isPresent()
-                .get()
-                .isEqualTo(LogSafety.SAFE);
+        assertThat(SafetyUtils.getUsageTimeSafety(field)).isPresent().get().isEqualTo(LogSafety.SAFE);
     }
 
     @Test
     public void referenceField() {
         FieldDefinition field = FieldDefinition.builder()
                 .fieldName(FieldName.of("testField"))
-                .type(REFERENCE)
+                .type(Type.primitive(PrimitiveType.BEARERTOKEN))
                 .build();
-        assertThat(SafetyUtils.getUsageTimeSafety(field, safetyEvaluator)).isEmpty();
+        assertThat(SafetyUtils.getUsageTimeSafety(field)).isEmpty();
     }
 
     @Test
     public void referenceFieldWrapper() {
         FieldDefinition field = FieldDefinition.builder()
                 .fieldName(FieldName.of("testField"))
-                .type(Type.list(ListType.builder().itemType(REFERENCE).build()))
+                .type(Type.list(ListType.builder()
+                        .itemType(Type.primitive(PrimitiveType.BEARERTOKEN))
+                        .build()))
                 .build();
-        assertThat(SafetyUtils.getUsageTimeSafety(field, safetyEvaluator)).isEmpty();
+        assertThat(SafetyUtils.getUsageTimeSafety(field)).isEmpty();
     }
 }


### PR DESCRIPTION
If an Alias, Field, or Argument is an external import type, use the underlying import's safety instead of the declared safety (which will be empty). Converts all usages of AliasDefinition.getSafety(), FieldDefinition.getSafety(), and ArgumentDefinition.getSafety() to the corresponding wrapper methods in SafetyUtils.java.